### PR TITLE
Prototype for Genotyper interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,11 +27,14 @@ include_directories(
 )
 
 file(GLOB_RECURSE SRC_FILES
-        ${PROJECT_SOURCE_DIR}/src/*.cpp
-        ${PROJECT_SOURCE_DIR}/src/*.h
-        )
+    ${PROJECT_SOURCE_DIR}/src/*.h
+)
 
-add_executable(${PROJECT_NAME} ${SRC_FILES})
+file(GLOB_RECURSE SIMPLE_GENOTYPER_FILES
+        ${PROJECT_SOURCE_DIR}/examples/simple_genotyper/*.cpp
+)
+
+add_executable(simple_genotyper ${SRC_FILES} ${SIMPLE_GENOTYPER_FILES})
 
 #enable_testing()
 #add_subdirectory(test)

--- a/examples/simple_genotyper/simple_genotyper.cpp
+++ b/examples/simple_genotyper/simple_genotyper.cpp
@@ -1,0 +1,42 @@
+#include "Genotyper.h"
+#include <map>
+#include <string>
+#include <iostream>
+
+/**
+ * Simple genotyper, the genotype information is given as a map,
+ * and all it does is to compute max likelihood - 2nd max likelihood.
+ */
+using GenotypingDataMap = const std::map<std::string, double>;
+class SimpleGenotyper : public Genotyper {
+public:
+  SimpleGenotyper() = default;
+  virtual ~SimpleGenotyper() = default;
+  
+  virtual double get_genotype_confidence (const void* data) const {
+    GenotypingDataMap* genotyping_data_map = (GenotypingDataMap*)(data);
+
+    double max_likelihood = genotyping_data_map->at("max_likelihood");
+    double second_max_likelihood = genotyping_data_map->at("second_max_likelihood");
+    double genotype_confidence = max_likelihood - second_max_likelihood;
+    return genotype_confidence;
+  }
+};
+
+
+int main() {
+  GenotypingDataMap genotyping_data_map_1 = {
+      {"max_likelihood", 15},
+      {"second_max_likelihood", 8.5}
+  };
+  GenotypingDataMap genotyping_data_map_2 = {
+      {"max_likelihood", 20},
+      {"second_max_likelihood", 19.5}
+  };
+
+  SimpleGenotyper simple_genotyper;
+  std::cout << "1st gt conf = " << simple_genotyper.get_genotype_confidence(&genotyping_data_map_1) << std::endl;
+  std::cout << "2nd gt conf = " << simple_genotyper.get_genotype_confidence(&genotyping_data_map_2) << std::endl;
+
+  return 0;
+}

--- a/src/Genotyper.h
+++ b/src/Genotyper.h
@@ -1,0 +1,36 @@
+#ifndef GCP_GENOTYPER_H
+#define GCP_GENOTYPER_H
+
+
+/**
+ * Generic class that represents a genotyper that genotypes VCF records or generic data.
+ */
+class Genotyper {
+public:
+  /**
+   * Concrete genotyper configuration must be initialised here.
+   */
+  Genotyper() = default;
+
+  /**
+   * Concrete genotyper cleanup.
+   */
+  virtual ~Genotyper() = default;
+
+  // disabling copy and move ctor, and assignment op (always good to be extra safe in C++)
+  Genotyper(const Genotyper& other) = delete;
+  Genotyper(Genotyper&& other) = delete;
+  Genotyper& operator=(const Genotyper& other) = delete;
+  Genotyper& operator=(Genotyper&& other) = delete;
+
+  /**
+   * Compute the genotype confidence given the data.
+   * TODO: there are safer ways to do this instead of using void*, which can be error prone,
+   *        but all options involve adding dependencies or updating C++ version, e.g.:
+   *        1. https://en.cppreference.com/w/cpp/utility/any (requires C++17);
+   *        2. https://www.boost.org/doc/libs/1_72_0/doc/html/any.html#id-1.3.5.3 (requires boost);
+   */
+  virtual double get_genotype_confidence (const void* data) const = 0;
+};
+
+#endif // GCP_GENOTYPER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,0 @@
-int main(){
-  return 0;
-}


### PR DESCRIPTION
I think `Genotyper` (see `Genotyper.h`) interface should be kept as simple as possible, with only methods this GCP code needs. Looking at the Minos code, I think that the only thing we need to know is how to build a genotyper (thus, constructor, which will be inherited and implemented by users), and how to get the confidence of a call given arbitrary information (which could be `VCF` records, or any other information - this is user-specific data - that is why `get_genotype_confidence` receives a `const void* data` as parameter).

`simple_genotyper.cpp` contains a very simple usage (inheritance) of this class.

This is totally prototyping, all of this could be thrown out. It is more for discussion. There could be several methods lacking in the `Genotyper` interface to make this work, if we choose to go this way.

I don't have much experience building libraries, and the requirement that it should be generic as possible seems to make it a bit more challenging, so this is more maybe to open the discussion with something more concrete? Or it might be just bad as we might get biased towards already produced code...


Edit:

Might be good to add a bit of motivation for this interface:
1. Genotyping of simulated variants will be done using only the local `pandora` genotyping (i.e. the genotyping which depends only on the coverage of the alleles). However, we know that the global `pandora` genotyping performs better than the local one (and that is what we will use in the paper), but the global depends on the ML path inferred by mapping multisample reads to a PRG. Adding the information of a ML path or any external information to the Genotyper in the GCP looks too tightly coupled to pandora, so it is better to not do this and just use the local `pandora` genotyping. This genotyping does not rely on the ML path;

2. Local `pandora` genotyping (see `SampleInfo::genotype_from_coverage()`) needs:
	2.1. min_allele_covg
	2.2. min_fraction_allele_covg
	2.3. exp_depth_covg
	2.4. min_kmer_covg
	2.5. error_rate
	2.6. min_site_total_covg
	2.7. min_site_diff_covg
	2.8. confidence_threshold
Several of these parameters are pandora specific. Other tool (e.g. `gramtools`) might have some other stuff, so that is why `Genotyper::get_genotype_confidence()` must be defined by the user and receive arbitrary data for genotyping.